### PR TITLE
Add fn `single`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## UNRELEASED
 
-- [#6](https://github.com/yihuang/non-empty-vec/pull/6) Remove unsafe `AsMut` implementation.
+- [#6](https://github.com/yihuang/non-empty-vec/pull/6) Remove unsafe `AsMut` implementation.
+- [#3](https://github.com/yihuang/non-empty-vec/pull/3) Change `new` to construct singleton.
 
 ## v0.1.2
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,17 +17,8 @@ pub struct NonEmpty<T>(Vec<T>);
 
 impl<T> NonEmpty<T> {
     #[inline]
-    pub fn new(vec: Vec<T>) -> Option<NonEmpty<T>> {
-        if vec.is_empty() {
-            None
-        } else {
-            Some(NonEmpty(vec))
-        }
-    }
-
-    #[inline]
-    pub fn single(val: T) -> Self {
-        Self(vec![val])
+    pub fn new(v: T) -> Self {
+        Self(vec![v])
     }
 
     #[inline]
@@ -239,7 +230,7 @@ mod tests {
         );
 
         // Single
-        let single = NonEmpty::single(15_i32);
+        let single = NonEmpty::new(15_i32);
         assert_eq!(single.len().get(), 1);
         assert_eq!(single[0], 15);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,11 @@ impl<T> NonEmpty<T> {
     }
 
     #[inline]
+    pub fn single(val: T) -> Self {
+        Self(vec![val])
+    }
+
+    #[inline]
     pub fn as_slice(&self) -> &[T] {
         &self.0
     }
@@ -232,6 +237,11 @@ mod tests {
             list.iter().map(|n| n * 2).collect::<Vec<_>>(),
             vec![2, 4, 6]
         );
+
+        // Single
+        let single = NonEmpty::single(15_i32);
+        assert_eq!(single.len().get(), 1);
+        assert_eq!(single[0], 15);
     }
 
     #[cfg(feature = "serde")]


### PR DESCRIPTION
Adds an infallible associated function to construct a `NonEmpty` from a single value.