### PR TITLE
Add macro similar to std's `vec!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## UNRELEASED
 
 - [#6](https://github.com/yihuang/non-empty-vec/pull/6) Remove unsafe `AsMut` implementation.
-- [#3](https://github.com/yihuang/non-empty-vec/pull/3) Change `new` to construct singleton.
+- [#3](https://github.com/yihuang/non-empty-vec/pull/3) Change `new` to construct singleton.
+- [#4](https://github.com/yihuang/non-empty-vec/pull/4) Add macro similar to std's `vec!`
 
 ## v0.1.2
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,13 @@ impl<T> NonEmpty<T> {
         Self(vec![v])
     }
 
+    /// Constructs a non-empty vec without checking its size.
+    /// This is marked `unsafe` as unsafe code elsewhere may rely on `NonEmpty`'s invariant.
+    #[inline]
+    pub unsafe fn new_unchecked(vec: Vec<T>) -> Self {
+        Self(vec)
+    }
+
     #[inline]
     pub fn as_slice(&self) -> &[T] {
         &self.0
@@ -194,6 +201,32 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for NonEmpty<T> {
         Self::try_from(<Vec<T>>::deserialize(deserializer)?)
             .map_err(|_| D::Error::custom("empty vector"))
     }
+}
+
+/// Constructs a [`NonEmpty`] vector, similar to std's `vec` macro.
+/// # Examples
+/// Proper use.
+/// ```
+/// # use non_empty_vec::*;
+/// assert_eq!(
+///     ne_vec![1, 2, 3],
+///     NonEmpty::new(vec![1, 2, 3_i32]).unwrap(),
+/// );
+/// ```
+/// Improper use.
+/// ```compile_fail
+/// # use non_empty_vec::*;
+/// // the following line should fail to compile.
+/// let _ = ne_vec![];
+/// ```
+#[macro_export]
+macro_rules! ne_vec {
+    () => {
+        ::std::compile_error!("`NonEmpty` vector must be non-empty")
+    };
+    ($($x:expr),+ $(,)?) => {
+        unsafe { $crate::NonEmpty::new_unchecked(vec![$($x),+]) }
+    };
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,9 +208,10 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for NonEmpty<T> {
 /// Proper use.
 /// ```
 /// # use non_empty_vec::*;
+/// # use std::convert::TryFrom;
 /// assert_eq!(
 ///     ne_vec![1, 2, 3],
-///     NonEmpty::new(vec![1, 2, 3_i32]).unwrap(),
+///     NonEmpty::try_from(vec![1, 2, 3_i32]).unwrap(),
 /// );
 /// ```
 /// Improper use.


### PR DESCRIPTION
Adds a macro for making `NonEmpty` ""literals"" -- verifies the size at compile-time, to avoid needing `.unwrap()`