### PR TITLE
Derive Hash and add missing import to tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 /target
 **/*.rs.bk
 Cargo.lock

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 /// * `len` returns `NonZeroUsize` and `is_empty` always returns `false`.
 /// * `first(_mut)`, `last(_mut)`, `split_first(_mut)`, `split_last(_mut)` don't return `Option`.
 /// * `pop` returns `None` if there is only one element in it.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NonEmpty<T>(Vec<T>);
 
 impl<T> NonEmpty<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,6 +232,8 @@ macro_rules! ne_vec {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[cfg(feature = "serde")]
     #[test]
     fn it_works() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,7 +234,6 @@ macro_rules! ne_vec {
 mod tests {
     use super::*;
 
-    #[cfg(feature = "serde")]
     #[test]
     fn it_works() {
         // From


### PR DESCRIPTION
I did two things:

1. Add Hash to the list of derives
2. Add missing import to test mod. When I tried to run the tests with serde enabled, it didn't compile.