### PR TITLE
Add truncate method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.2.2
+
+- [#11](https://github.com/yihuang/non-empty-vec/pull/11) Add `truncate` method
+
 ## v0.2.1
 
 - [#8](https://github.com/yihuang/non-empty-vec/pull/8) Add `AsMut<[T]>`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "non-empty-vec"
 description = "`NonEmpty` vector implementation, ensure non-emptiness by construction."
-version = "0.2.1"
+version = "0.2.2"
 authors = ["yihuang <yi.codeplayer@gmail.com>"]
 license = "MIT"
 edition = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,11 @@ impl<T> NonEmpty<T> {
     }
 
     #[inline]
+    pub fn truncate(&mut self, len: NonZeroUsize) {
+        self.0.truncate(len.get())
+    }
+
+    #[inline]
     pub fn iter_mut(&mut self) -> IterMut<'_, T> {
         self.0.iter_mut()
     }


### PR DESCRIPTION
Since truncate only accepts a NonZeroUsize, it is safe to truncate the
NonEmpty to the given len.