### PR TITLE
add size expression macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.2.3
+
+- [#12](https://github.com/yihuang/non-empty-vec/pull/12) Add `ne_vec![element; n]` macro.
+
 ## v0.2.2
 
 - [#11](https://github.com/yihuang/non-empty-vec/pull/11) Add `truncate` method

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "non-empty-vec"
 description = "`NonEmpty` vector implementation, ensure non-emptiness by construction."
-version = "0.2.2"
+version = "0.2.3"
 authors = ["yihuang <yi.codeplayer@gmail.com>"]
 license = "MIT"
 edition = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,10 +289,12 @@ macro_rules! ne_vec {
         unsafe { $crate::NonEmpty::new_unchecked(vec![$($x),+]) }
     };
     ($elem:expr; 0) => {
-        ::std::compile_error!("`NonEmpty` vector must be non-empty")
+        // if 0 is passed to the macro we can generate a good compile error
+        ne_vec![]
     };
     ($elem:expr; $n:literal) => {{
-        // $n cannot be zero as this macro is only called if the rule above ($elem:expr; 0) does not match
+        // extra guard to reject compilation if $n ends up being 0 in some other way (e.g. ne_vec![1; 0usize])
+        const _ASSERT_NON_ZERO: [(); $n - 1] = [(); $n - 1];
         unsafe { $crate::NonEmpty::new_unchecked(vec![$elem; $n]) }
     }};
     ($elem:expr; $n:expr) => {{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,11 +272,21 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for NonEmpty<T> {
 /// Improper use.
 /// ```compile_fail
 /// # use non_empty_vec::*;
-/// // the following line(s) should fail to compile.
 /// let _ = ne_vec![];
-/// let _ = ne_vec![1; 0];
+/// ```
 ///
-/// // the following line should panic.
+/// ```compile_fail
+/// # use non_empty_vec::*;
+/// let _ = ne_vec![1; 0];
+/// ```
+///
+/// ```compile_fail
+/// # use non_empty_vec::*;
+/// let _ = ne_vec![1; 0usize];
+/// ```
+///
+/// ```should_panic
+/// # use non_empty_vec::*;
 /// let n = 0;
 /// let _ = ne_vec![1; n];
 /// ```


### PR DESCRIPTION
#4 introduced a `vec![]`-like macro, but it doesn't support the convenient "size expression" syntax `vec![element; N]` that fills the vector with `N` clones of `element`.
This macro also includes a zero check to assert the validity invariant `N != 0`.