### PR TITLE
Add type `NonEmptySlice`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,33 +275,6 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for NonEmpty<T> {
 pub struct NonEmptySlice<T>([T]);
 
 impl<T> NonEmptySlice<T> {
-    /// Creates a new `NonEmptySlice` from a primitive slice. Returns [`None`] if the slice is empty.
-    /// # Examples
-    /// ```
-    /// # use non_empty_vec::NonEmptySlice;
-    /// // Non-empty input
-    /// assert!(NonEmptySlice::new(&[1]).is_some());
-    /// // Empty input
-    /// assert!(NonEmptySlice::<()>::new(&[]).is_none());
-    /// ```
-    #[inline]
-    pub fn new(slice: &[T]) -> Option<&Self> {
-        if !slice.is_empty() {
-            unsafe { Some(Self::unchecked(slice)) }
-        } else {
-            None
-        }
-    }
-    /// Creates a new `NonEmptySlice` from a primitive slice. Returns [`None`] if the slice is empty.
-    #[inline]
-    pub fn new_mut(slice: &mut [T]) -> Option<&mut Self> {
-        if !slice.is_empty() {
-            unsafe { Some(Self::unchecked_mut(slice)) }
-        } else {
-            None
-        }
-    }
-
     /// Creates a new `NonEmptySlice` without checking the length.
     /// # Safety
     /// Ensure that the input slice is not empty.
@@ -338,6 +311,33 @@ impl<T> NonEmptySlice<T> {
         // SAFETY: This type is `repr(transparent)`, so we can safely
         // cast the references like this.
         &mut *(slice as *mut _ as *mut Self)
+    }
+
+    /// Creates a new `NonEmptySlice` from a primitive slice. Returns [`None`] if the slice is empty.
+    /// # Examples
+    /// ```
+    /// # use non_empty_vec::NonEmptySlice;
+    /// // Non-empty input
+    /// assert!(NonEmptySlice::new(&[1]).is_some());
+    /// // Empty input
+    /// assert!(NonEmptySlice::<()>::new(&[]).is_none());
+    /// ```
+    #[inline]
+    pub const fn from_slice(slice: &[T]) -> Option<&Self> {
+        if !slice.is_empty() {
+            unsafe { Some(Self::unchecked(slice)) }
+        } else {
+            None
+        }
+    }
+    /// Creates a new `NonEmptySlice` from a primitive slice. Returns [`None`] if the slice is empty.
+    #[inline]
+    pub fn from_mut_slice(slice: &mut [T]) -> Option<&mut Self> {
+        if !slice.is_empty() {
+            unsafe { Some(Self::unchecked_mut(slice)) }
+        } else {
+            None
+        }
     }
 
     /// Converts this `NonEmptySlice` into a primitive slice.
@@ -519,13 +519,13 @@ impl<T> NonEmptySlice<T> {
 impl<'a, T> TryFrom<&'a [T]> for &'a NonEmptySlice<T> {
     type Error = EmptyError;
     fn try_from(value: &'a [T]) -> Result<Self, Self::Error> {
-        NonEmptySlice::new(value).ok_or(EmptyError)
+        NonEmptySlice::from_slice(value).ok_or(EmptyError)
     }
 }
 impl<'a, T> TryFrom<&'a mut [T]> for &'a mut NonEmptySlice<T> {
     type Error = EmptyError;
     fn try_from(value: &'a mut [T]) -> Result<Self, Self::Error> {
-        NonEmptySlice::new_mut(value).ok_or(EmptyError)
+        NonEmptySlice::from_mut_slice(value).ok_or(EmptyError)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,9 +318,9 @@ impl<T> NonEmptySlice<T> {
     /// ```
     /// # use non_empty_vec::NonEmptySlice;
     /// // Non-empty input
-    /// assert!(NonEmptySlice::new(&[1]).is_some());
+    /// assert!(NonEmptySlice::from_slice(&[1]).is_some());
     /// // Empty input
-    /// assert!(NonEmptySlice::<()>::new(&[]).is_none());
+    /// assert!(NonEmptySlice::<()>::from_slice(&[]).is_none());
     /// ```
     #[inline]
     pub const fn from_slice(slice: &[T]) -> Option<&Self> {
@@ -464,7 +464,7 @@ impl<T> NonEmptySlice<T> {
     /// smaller references, which can each be mutated independently without
     /// tripping off the borrow checker.
     ///
-    /// # Example
+    /// # Examples
     /// ```
     /// # use non_empty_vec::ne_vec;
     /// let mut v = ne_vec![1, 2, 3, 4];
@@ -472,6 +472,15 @@ impl<T> NonEmptySlice<T> {
     /// *first *= 2;
     /// rest[1] += 2;
     /// assert_eq!(v, ne_vec![2, 2, 5, 4]);
+    /// ```
+    ///
+    /// Only one element.
+    /// ```
+    /// # use non_empty_vec::ne_vec;
+    /// let mut v = ne_vec![4];
+    /// let (first, rest) = v.split_first_mut();
+    /// assert_eq!(*first, 4);
+    /// assert_eq!(rest, &[]);
     /// ```
     #[inline]
     pub fn split_first_mut(&mut self) -> (&mut T, &mut [T]) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,6 +280,14 @@ pub struct NonEmptySlice<T>([T]);
 
 impl<T> NonEmptySlice<T> {
     /// Creates a new `NonEmptySlice` from a primitive slice. Returns [`None`] if the slice is empty.
+    /// # Examples
+    /// ```
+    /// # use non_empty_vec::NonEmptySlice;
+    /// // Non-empty input
+    /// assert!(NonEmptySlice::new(&[1]).is_some());
+    /// // Empty input
+    /// assert!(NonEmptySlice::<()>::new(&[]).is_none());
+    /// ```
     #[inline]
     pub fn new(slice: &[T]) -> Option<&Self> {
         if !slice.is_empty() {
@@ -301,6 +309,23 @@ impl<T> NonEmptySlice<T> {
     /// Creates a new `NonEmptySlice` without checking the length.
     /// # Safety
     /// Ensure that the input slice is not empty.
+    /// # Examples
+    /// For a slice that is known not to be empty.
+    /// ```
+    /// # use non_empty_vec::NonEmptySlice;
+    /// let s = unsafe {
+    ///     // SAFETY: The passed slice is non-empty.
+    ///     NonEmptySlice::unchecked(&[1])
+    /// };
+    /// assert_eq!(s, &[1]);
+    /// ```
+    /// Improper use (instant undefined behavior).
+    /// ```ignore
+    /// # use non_empty_vec::NonEmptySlice;
+    /// let s: &NonEmptySlice<String> = unsafe { NonEmptySlice::unchecked(&[]) };
+    /// // Please don't try this.
+    /// println!("{}", s.first().as_str());
+    /// ```
     #[inline]
     pub const unsafe fn unchecked(slice: &[T]) -> &Self {
         debug_assert!(!slice.is_empty());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,17 +7,13 @@ use std::vec::IntoIter;
 #[cfg(feature = "serde")]
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 
-/// Call this macro to assert that the current code path is unreachable due to
-/// a non-empty invariant. This avoids a lot of ceremony in the implementation,
-/// since almost all unsafe code in this crate relies on the same invariant.
-macro_rules! unreachable_non_empty {
+/// Calls [`std::hint::unreachable_unchecked`] in release mode, and panics in debug mode.
+macro_rules! unreachable_unchecked {
     () => {{
         #[cfg(debug_assertions)]
         ::std::unreachable!();
         #[allow(unreachable_code)]
-        unsafe {
-            ::std::hint::unreachable_unchecked()
-        }
+        ::std::hint::unreachable_unchecked()
     }};
 }
 
@@ -389,7 +385,8 @@ impl<T> NonEmptySlice<T> {
         if let [first, ..] = self.as_slice() {
             first
         } else {
-            unreachable_non_empty!()
+            // SAFETY: This instance is non-empty, so the above pattern will always match.
+            unsafe { unreachable_unchecked!() }
         }
     }
     /// Returns a mutable reference to the first element of this slice.
@@ -405,7 +402,8 @@ impl<T> NonEmptySlice<T> {
         if let [first, ..] = self.as_mut_slice() {
             first
         } else {
-            unreachable_non_empty!()
+            // SAFETY: This instance is non-empty, so the above pattern will always match.
+            unsafe { unreachable_unchecked!() }
         }
     }
 
@@ -421,7 +419,8 @@ impl<T> NonEmptySlice<T> {
         if let [.., last] = self.as_slice() {
             last
         } else {
-            unreachable_non_empty!()
+            // SAFETY: This instance is non-empty, so the above pattern will always match.
+            unsafe { unreachable_unchecked!() }
         }
     }
     /// Returns a mutable reference to the last element of this slice.
@@ -437,7 +436,8 @@ impl<T> NonEmptySlice<T> {
         if let [.., last] = self.as_mut_slice() {
             last
         } else {
-            unreachable_non_empty!()
+            // SAFETY: This instance is non-empty, so the above pattern will always match.
+            unsafe { unreachable_unchecked!() }
         }
     }
 
@@ -452,7 +452,8 @@ impl<T> NonEmptySlice<T> {
         if let [first, rest @ ..] = self.as_slice() {
             (first, rest)
         } else {
-            unreachable_non_empty!()
+            // SAFETY: This instance is non-empty, so the above pattern will always match.
+            unsafe { unreachable_unchecked!() }
         }
     }
     /// Splits this slice into
@@ -477,7 +478,8 @@ impl<T> NonEmptySlice<T> {
         if let [first, rest @ ..] = self.as_mut_slice() {
             (first, rest)
         } else {
-            unreachable_non_empty!()
+            // SAFETY: This instance is non-empty, so the above pattern will always match.
+            unsafe { unreachable_unchecked!() }
         }
     }
 
@@ -492,7 +494,8 @@ impl<T> NonEmptySlice<T> {
         if let [rest @ .., last] = self.as_slice() {
             (last, rest)
         } else {
-            unreachable_non_empty!()
+            // SAFETY: This instance is non-empty, so the above pattern will always match.
+            unsafe { unreachable_unchecked!() }
         }
     }
     /// Splits this slice into
@@ -507,7 +510,8 @@ impl<T> NonEmptySlice<T> {
         if let [rest @ .., last] = self.as_mut_slice() {
             (last, rest)
         } else {
-            unreachable_non_empty!()
+            // SAFETY: This instance is non-empty, so the above pattern will always match.
+            unsafe { unreachable_unchecked!() }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,6 +354,26 @@ impl<T> NonEmptySlice<T> {
         Box::from_raw(ptr)
     }
 
+    /// Converts a reference into a [non-empty slice](NonEmptySlice) of length `1`.
+    /// # Example
+    /// ```
+    /// # use non_empty_vec::NonEmptySlice;
+    /// let slice = NonEmptySlice::from_ref(&5);
+    /// assert_eq!(slice, &[5]);
+    /// ```
+    #[inline]
+    pub fn from_ref(val: &T) -> &Self {
+        let slice = core::slice::from_ref(val);
+        // SAFETY: `slice::from_ref` returns a slice of length 1, so it's non-empty.
+        unsafe { Self::unchecked(slice) }
+    }
+    /// Converts a mutable reference into a [non-empty slice](NonEmptySlice) of length `1`.
+    #[inline]
+    pub fn from_mut(val: &mut T) -> &mut Self {
+        let slice = core::slice::from_mut(val);
+        unsafe { Self::unchecked_mut(slice) }
+    }
+
     /// Creates a new `NonEmptySlice` from a primitive slice. Returns [`None`] if the slice is empty.
     /// # Examples
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,6 +360,7 @@ impl<T> NonEmptySlice<T> {
     pub const fn len(&self) -> NonZeroUsize {
         unsafe { NonZeroUsize::new_unchecked(self.0.len()) }
     }
+    /// Returns `false`.
     #[inline]
     pub const fn is_empty(&self) -> bool {
         false
@@ -376,6 +377,13 @@ impl<T> NonEmptySlice<T> {
         self.0.as_mut_ptr()
     }
 
+    /// Returns a reference to the first element of this slice.
+    /// # Example
+    /// ```
+    /// # use non_empty_vec::ne_vec;
+    /// let v = ne_vec![1, 2, 3];
+    /// assert_eq!(v.first(), &1);
+    /// ```
     #[inline]
     pub const fn first(&self) -> &T {
         if let [first, ..] = self.as_slice() {
@@ -384,6 +392,14 @@ impl<T> NonEmptySlice<T> {
             unreachable_non_empty!()
         }
     }
+    /// Returns a mutable reference to the first element of this slice.
+    /// # Example
+    /// ```
+    /// # use non_empty_vec::ne_vec;
+    /// let mut v = ne_vec![1, 2, 3];
+    /// *v.first_mut() = 10;
+    /// assert_eq!(v, ne_vec![10, 2, 3]);
+    /// ```
     #[inline]
     pub fn first_mut(&mut self) -> &mut T {
         if let [first, ..] = self.as_mut_slice() {
@@ -393,6 +409,13 @@ impl<T> NonEmptySlice<T> {
         }
     }
 
+    /// Returns a reference to the last element of this slice.
+    /// # Example
+    /// ```
+    /// # use non_empty_vec::ne_vec;
+    /// let mut v = ne_vec![1, 2, 3];
+    /// assert_eq!(v.last(), &3);
+    /// ```
     #[inline]
     pub const fn last(&self) -> &T {
         if let [.., last] = self.as_slice() {
@@ -401,6 +424,14 @@ impl<T> NonEmptySlice<T> {
             unreachable_non_empty!()
         }
     }
+    /// Returns a mutable reference to the last element of this slice.
+    /// # Example
+    /// ```
+    /// # use non_empty_vec::ne_vec;
+    /// let mut v = ne_vec![1, 2, 3];
+    /// *v.last_mut() = 10;
+    /// assert_eq!(v, ne_vec![1, 2, 10]);
+    /// ```
     #[inline]
     pub fn last_mut(&mut self) -> &mut T {
         if let [.., last] = self.as_mut_slice() {
@@ -410,6 +441,12 @@ impl<T> NonEmptySlice<T> {
         }
     }
 
+    /// Splits this slice into
+    /// * A reference to the first element.
+    /// * A slice to the rest of the elements.
+    ///
+    /// This method is not usually very helpful, but it may shorten some expressions.
+    /// It is mainly included for the sake of parity with [`split_first_mut`](#method.split_first_mut).
     #[inline]
     pub const fn split_first(&self) -> (&T, &[T]) {
         if let [first, rest @ ..] = self.as_slice() {
@@ -418,6 +455,23 @@ impl<T> NonEmptySlice<T> {
             unreachable_non_empty!()
         }
     }
+    /// Splits this slice into
+    /// * A mutable reference to the first element.
+    /// * A mutable slice to the rest of the elements.
+    ///
+    /// This method is useful for breaking up a contiguous slice into multiple
+    /// smaller references, which can each be mutated independently without
+    /// tripping off the borrow checker.
+    ///
+    /// # Example
+    /// ```
+    /// # use non_empty_vec::ne_vec;
+    /// let mut v = ne_vec![1, 2, 3, 4];
+    /// let (first, rest) = v.split_first_mut();
+    /// *first *= 2;
+    /// rest[1] += 2;
+    /// assert_eq!(v, ne_vec![2, 2, 5, 4]);
+    /// ```
     #[inline]
     pub fn split_first_mut(&mut self) -> (&mut T, &mut [T]) {
         if let [first, rest @ ..] = self.as_mut_slice() {
@@ -427,6 +481,12 @@ impl<T> NonEmptySlice<T> {
         }
     }
 
+    /// Splits this slice into
+    /// * A reference to the last element.
+    /// * A slice to the rest of the elements.
+    ///
+    /// This method is not usually very helpful, but it may shorten some expressions.
+    /// It is mainly included for the sake of parity with [`split_last_mut`](#method.split_last_mut).
     #[inline]
     pub fn split_last(&self) -> (&T, &[T]) {
         if let [rest @ .., last] = self.as_slice() {
@@ -435,6 +495,13 @@ impl<T> NonEmptySlice<T> {
             unreachable_non_empty!()
         }
     }
+    /// Splits this slice into
+    /// * A mutable reference to the last element.
+    /// * A mutable slice to the rest of the elements.
+    ///
+    /// This method is useful for breaking up a contiguous slice into multiple
+    /// smaller references, which can each be mutated independently without
+    /// tripping off the borrow checker.
     #[inline]
     pub fn split_last_mut(&mut self) -> (&mut T, &mut [T]) {
         if let [rest @ .., last] = self.as_mut_slice() {


### PR DESCRIPTION
* Added the DST `NonEmptySlice`
    * Wrapper around a slice that guarantees it has at least one element.
    * Defines many helper methods that benefit from the non-empty restriction, such as `first`, `split_last_mut`, etc.
    * impl `Deref<Target = [T]>`, for the rest of the methods we expect.
* Change `NonEmpty` to impl `Deref<Target = NonEmptySlice>`.
    * This means the majority of `NonEmpty`'s methods are now unnecessary, since we get them through the `Deref` impl.
* Added a significant amount of documentation.